### PR TITLE
Raise errors on all requests | Remove extra forward slash from download/delete request paths

### DIFF
--- a/lib/egnyte/file.rb
+++ b/lib/egnyte/file.rb
@@ -20,11 +20,11 @@ module Egnyte
     # :content_length_proc
     # :progress_proc
     def stream( opts={} )
-      @session.streaming_download( "#{fs_path('fs-content')}/#{path}", opts )
+      @session.streaming_download( "#{fs_path('fs-content')}#{path}", opts )
     end
 
     def delete
-      @session.delete("#{fs_path}/#{path}")
+      @session.delete("#{fs_path}#{path}")
     end
 
     def self.find(session, path)
@@ -33,7 +33,7 @@ module Egnyte
       file = File.new({
         'path' => path
       }, session)
-      
+
       parsed_body = session.get("#{file.fs_path}#{path}")
 
       raise FileExpected if parsed_body['is_folder']

--- a/lib/egnyte/session.rb
+++ b/lib/egnyte/session.rb
@@ -10,9 +10,11 @@ module Egnyte
 
       @strategy = strategy # the authentication strategy to use.
       raise Egnyte::UnsupportedAuthStrategy unless [:implicit, :password].include? @strategy
-      
+
       @backoff = backoff # only two requests are allowed a second by Egnyte.
       @api = 'pubapi' # currently we only support the public API.
+
+      @username = opts[:username]
 
       # the domain of the egnyte account to interact with.
       raise Egnyte::DomainRequired unless @domain = opts[:domain]
@@ -29,7 +31,7 @@ module Egnyte
         if opts[:access_token]
           @access_token = OAuth2::AccessToken.new(@client, opts[:access_token])
         else
-          raise Egnyte::OAuthUsernameRequired unless @username = opts[:username]
+          raise Egnyte::OAuthUsernameRequired unless @username
           raise Egnyte::OAuthPasswordRequired unless opts[:password]
           if true #OS.windows?
             body = {
@@ -129,7 +131,7 @@ module Egnyte
         :progress_proc => opts[:progress_proc],
         'Authorization' => "Bearer #{@access_token.token}"
       }
-      
+
       open(url, params)
     end
 
@@ -144,7 +146,7 @@ module Egnyte
         http.cert_store.add_file("#{::File.dirname(__FILE__)}/../../includes/cacert.pem")
       end
       #http.set_debug_output($stdout)
-      
+
       unless request.content_type == "application/x-www-form-urlencoded"
         request.add_field('Authorization', "Bearer #{@access_token.token}")
       end
@@ -188,7 +190,7 @@ module Egnyte
       raise RequestError.new(parsed_body) if status >= 400
 
       parsed_body
-      
+
     end
 
   end

--- a/lib/egnyte/session.rb
+++ b/lib/egnyte/session.rb
@@ -159,38 +159,37 @@ module Egnyte
 
       # puts "#{response.code.to_i} ||||| #{response.body}"
 
-      return_parsed_response ? parse_response( response.code.to_i, response.body ) : response
+
+      return_value = return_parsed_response ? parse_response_body(response.body) : response
+      parse_response_code(response.code.to_i, return_value)
+
+      return_value
     end
 
-    def parse_response( status, body )
-
-      begin
-        parsed_body = JSON.parse(body)
-      rescue
-        parsed_body = {}
-      end
-
-      # Handle known errors.
+    def parse_response_code(status, response)
       case status
       when 400
-        raise BadRequest.new(parsed_body)
+        raise BadRequest.new(response)
       when 401
-        raise NotAuthorized.new(parsed_body)
+        raise NotAuthorized.new(response)
       when 403
-        raise InsufficientPermissions.new(parsed_body)
+        raise InsufficientPermissions.new(response)
       when 404
-        raise RecordNotFound.new(parsed_body)
+        raise RecordNotFound.new(response)
       when 405
-        raise DuplicateRecordExists.new(parsed_body)
+        raise DuplicateRecordExists.new(response)
       when 413
-        raise FileSizeExceedsLimit.new(parsed_body)
+        raise FileSizeExceedsLimit.new(response)
       end
 
       # Handle all other request errors.
-      raise RequestError.new(parsed_body) if status >= 400
+      raise RequestError.new(response) if status >= 400
+    end
 
-      parsed_body
-
+    def parse_response_body(body)
+      JSON.parse(body)
+    rescue
+      {}
     end
 
   end

--- a/lib/egnyte/version.rb
+++ b/lib/egnyte/version.rb
@@ -1,3 +1,3 @@
 module Egnyte
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end

--- a/spec/file_spec.rb
+++ b/spec/file_spec.rb
@@ -55,4 +55,17 @@ describe Egnyte::File do
     end
   end
 
+  describe "#delete" do
+    it "should delete the file" do
+      stub_request(:get, "https://test.egnyte.com/pubapi/v1/fs/Shared/banana.txt")
+        .with(:headers => { 'Authorization' => 'Bearer access_token' })
+        .to_return(:body => File.read('./spec/fixtures/list_file.json'), :status => 200)
+
+      stub_request(:delete, "https://test.egnyte.com/pubapi/v1/fs/Shared/banana.txt")
+        .with(:headers => { 'Authorization' => 'Bearer access_token' })
+        .to_return(:body => '{"status":"no more banana"}', :status => 200)
+
+      expect(@client.file('Shared/banana.txt').delete).to eq({ "status" => "no more banana" })
+    end
+  end
 end

--- a/spec/file_spec.rb
+++ b/spec/file_spec.rb
@@ -29,7 +29,7 @@ describe Egnyte::File do
         .with(:headers => { 'Authorization' => 'Bearer access_token' })
         .to_return(:status => 404)
 
-      expect{@client.file('Shared/banana.txt')}.to raise_error( Egnyte::RecordNotFound ) 
+      expect{@client.file('Shared/banana.txt')}.to raise_error( Egnyte::RecordNotFound )
     end
 
     it "should raise FileExpected if path to folder provided" do
@@ -37,7 +37,21 @@ describe Egnyte::File do
         .with(:headers => { 'Authorization' => 'Bearer access_token' })
         .to_return(:body => File.read('./spec/fixtures/list_folder.json'), :status => 200)
 
-      expect{@client.file('/Shared')}.to raise_error( Egnyte::FileExpected ) 
+      expect{@client.file('/Shared')}.to raise_error( Egnyte::FileExpected )
+    end
+  end
+
+  describe "#download" do
+    it "should stream the file contents" do
+      stub_request(:get, "https://test.egnyte.com/pubapi/v1/fs/Shared/banana.txt")
+        .with(:headers => { 'Authorization' => 'Bearer access_token' })
+        .to_return(:body => File.read('./spec/fixtures/list_file.json'), :status => 200)
+
+      stub_request(:get, "https://test.egnyte.com/pubapi/v1/fs-content/Shared/banana.txt")
+        .with(:headers => { 'Authorization' => 'Bearer access_token' })
+        .to_return(:body => 'Banana Text', :status => 200)
+
+      expect(@client.file('Shared/banana.txt').download).to eq('Banana Text')
     end
   end
 


### PR DESCRIPTION
*Raise request errors for all requests:*
Currently these errors are only raised for requests whose responses are parsed, making it impossible to detect failures for certain requests.

*Remove extra forward slash:*
There's an extra one in there. This PR kills it.